### PR TITLE
Add coordinate transformer to support multiple wkid

### DIFF
--- a/src/main/js/bundles/dn_what3words/manifest.json
+++ b/src/main/js/bundles/dn_what3words/manifest.json
@@ -146,6 +146,10 @@
                 {
                     "name": "_what3WordsModel",
                     "providing": "dn_what3words.What3WordsModel"
+                },
+                {
+                    "name": "_coordinateTransformer",
+                    "providing": "ct.api.coordinatetransformer.CoordinateTransformer"
                 }
             ]
         },


### PR DESCRIPTION
map-init config for tests:

```json
"map-init": {
            "Config": {
                "basemaps": [
                    {
                        "id": "wmts_nw_dop",
                        "title": "Luftbild",
                        "description": "WMTS NRW DOP",
                        "basemap": {
                            "type": "WMTS",
                            "url": "http://www.wmts.nrw.de/dop/tiles/dop",
                            "activeLayer": {
                                "id": "DOP20"
                            }
                        },
                        "selected": true
                    }
                ],
                "map": {
                    "layers": []
                },
                "view": {
                    "viewmode": "2D",
                    "scale": 328083,
                    "center": {
                        "x": 405244,
                        "y": 5757339,
                        "spatialReference": {
                            "wkid": 25832
                        }
                    }
                }
            }
        }
```